### PR TITLE
Made compile on linux

### DIFF
--- a/premake.lua
+++ b/premake.lua
@@ -6,29 +6,28 @@ project "fmt"
 	targetdir ("build/bin/%{prj.name}")
 	objdir ("build/obj/%{prj.name}")
 
-	files {
-		"src/fmt.cc",
-    "src/format.cc",
-    "src/os.cc"
-	}
+
 
   includedirs {
     "include/"
   }
 
-	compileas "Module"
-
 
 	filter "system:linux"
 		cppdialect "C++2a"
 		systemversion "latest"
+    files {
+      "src/format.cc",
+    }
 
 
 	filter "system:windows"
 		cppdialect "C++20"
 		systemversion "latest"
-		defines {
-		}
+    compileas "Module"
+    files {
+      "src/fmt.cc",
+    }
 
 	filter "configurations:Debug"
 		runtime "Debug"


### PR DESCRIPTION
Compiles a normal cpp file, instead of compiling to a module like on
windows.

<!--
Please read the contribution guidelines before submitting a pull request:
https://github.com/fmtlib/fmt/blob/master/CONTRIBUTING.md.
By submitting this pull request, you agree that your contributions are licensed
under the {fmt} license, and agree to future changes to the licensing.
-->
